### PR TITLE
Address capitalization error in GitIgnore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/diagram/
+/Diagram/
 /bin/
 bin
 diagram


### PR DESCRIPTION
This PR addresses capitalization error in `.gitignore` file, resulting as `Diagram` folder not being filtered.